### PR TITLE
Improve watchdog behavior re. LTE modem deinit

### DIFF
--- a/terkin/datalogger.py
+++ b/terkin/datalogger.py
@@ -50,6 +50,9 @@ class TerkinDatalogger:
 
     def start(self):
 
+        # Start the watchdog for sanity.
+        self.device.start_watchdog()
+        
         # Report about wakeup reason and run wakeup tasks.
         self.device.resume()
 
@@ -60,8 +63,6 @@ class TerkinDatalogger:
 
         log.info('Starting %s', self.appname)
 
-        # Start the watchdog for sanity.
-        self.device.start_watchdog()
 
         # Configure RGB-LED according to settings.
         self.device.configure_rgb_led()

--- a/terkin/network/wifi.py
+++ b/terkin/network/wifi.py
@@ -316,10 +316,10 @@ class SystemWiFiMetrics:
             return
 
         stats = {
-            'system.wifi.bandwidth': self.station.bandwidth(),
+            # 'system.wifi.bandwidth': self.station.bandwidth(),
             'system.wifi.channel': self.station.channel(),
             #'system.wifi.protocol': self.station.wifi_protocol(),
-            'system.wifi.max_tx_power': self.station.max_tx_power(),
+            # 'system.wifi.max_tx_power': self.station.max_tx_power(),
             #'system.wifi.joined_ap_info': self.station.joined_ap_info(),
         }
 

--- a/terkin/sensor/button.py
+++ b/terkin/sensor/button.py
@@ -4,7 +4,7 @@
 # License: GNU General Public License, Version 3
 from machine import Timer
 from terkin import logging
-from terkin.sensor.touch import TouchPad
+# from terkin.sensor.touch import TouchPad
 
 log = logging.getLogger(__name__)
 
@@ -40,13 +40,14 @@ class ButtonManager:
         self.alarm = Timer.Alarm(self.check, ms=self.check_interval_ms, periodic=True)
 
     def setup_touchpad(self, pin, name, location):
-        button = Button(
-            name=name,
-            location=location,
-            adapter=TouchPad(pin, name, sensitivity=1000, duration=500),
-        )
-        log.info('Setting up %s', button)
-        self.buttons.append(button)
+        pass
+        # button = Button(
+        #     name=name,
+        #     location=location,
+        #     adapter=TouchPad(pin, name, sensitivity=1000, duration=500),
+        # )
+        # log.info('Setting up %s', button)
+        # self.buttons.append(button)
 
     def check(self, alarm):
         for button in self.buttons:


### PR DESCRIPTION
The device stopped at `lte.deinit()` so I moved the watchdog up.