### PR TITLE
add LoPy4 support in Bootloader

### DIFF
--- a/lib/mboot.py
+++ b/lib/mboot.py
@@ -38,7 +38,7 @@ class PlatformInfo:
             self.mcu = McuFamily.ESP32
             self.vendor = MicroPythonPlatform.Vanilla
 
-        if sys.platform in ['WiPy', 'LoPy', 'GPy', 'FiPy']:
+        if sys.platform in ['WiPy', 'LoPy', 'LoPy4', 'GPy', 'FiPy']:
             self.mcu = McuFamily.ESP32
             self.vendor = MicroPythonPlatform.Pycom
 


### PR DESCRIPTION
This adds `LoPy4` as a possible platform to the platform switch.