### PR TITLE
add socket import in LoRa module

### DIFF
--- a/terkin/network/lora.py
+++ b/terkin/network/lora.py
@@ -4,6 +4,7 @@
 # License: GNU General Public License, Version 3
 import time
 import binascii
+import socket
 from terkin import logging
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This adds a missing `import socket` statement to `lora.py`.