### PR TITLE
Skip reading WiFi sensors when WiFi is disabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,6 +99,8 @@ Development
 - Update 1-Wire/DS18X20 driver again.
   The DS18B20 driver now also supports parasite power mode. Thanks, @robert-hh!
 - Improve bootstrap messages
+- Add boolean flags for enabling/disabling Wifi and LoRa
+- Skip reading WiFi sensors when WiFi is disabled
 
 
 2019-08-19 0.6.0

--- a/terkin/datalogger.py
+++ b/terkin/datalogger.py
@@ -319,7 +319,7 @@ class TerkinDatalogger:
             # skip WiFi sensor registration when WiFi is disabled
             if sensor_type == 'system.wifi':
                 if not self.settings.get('networking.wifi.enabled'):
-                    log.info('WiFi is disabled, skipping sensor registration'.format(sensor_id, sensor_type))
+                    log.info('WiFi is disabled, skipping sensor registration')
                     continue
 
             # Resolve associated bus object.

--- a/terkin/datalogger.py
+++ b/terkin/datalogger.py
@@ -316,6 +316,12 @@ class TerkinDatalogger:
                 log.info('Sensor with id={} and type={} is disabled, skipping registration'.format(sensor_id, sensor_type))
                 continue
 
+            # skip WiFi sensor registration when WiFi is disabled
+            if sensor_type == 'system.wifi':
+                if not self.settings.get('networking.wifi.enabled'):
+                    log.info('WiFi is disabled, skipping sensor registration'.format(sensor_id, sensor_type))
+                    continue
+
             # Resolve associated bus object.
             sensor_bus = None
             sensor_bus_name = None


### PR DESCRIPTION
When WiFi is disabled completely, this skips the activation of the integrated `system.wifi` sensor.